### PR TITLE
Support for multiple private repositories + repository scoping + support for skipping auth when in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ You also need to add the required API permissions to have '`Azure DevOps user_im
 
 ![aad api permissions](https://imgur.com/aVd51d0.png)
 
+### Continuous integration
+To disable authentication within CI environments add the `--ci` flag which skips authentication when the `TF_BUILD` environment variable is set (which is automatically set in Azure DevOps build pipelines):
+```javascript
+  "scripts": {
+    "preinstall": "azure-devops-npm-auth --ci"
+    ...
+  },
+```
+It's also possible to specify a custom environment variable:
+```javascript
+  "scripts": {
+    "preinstall": "azure-devops-npm-auth --ci=MY_CUSTOM_VARIABLE"
+    ...
+  },
+```
 
 ## Special Thanks 👏
 

--- a/cli.ts
+++ b/cli.ts
@@ -10,6 +10,4 @@ const args = require("minimist")(process.argv.slice(2), {
   }
 });
 
-console.log(args);
-
 (async () => await run(args.client_id, args.tenant_id, args.ci))();

--- a/cli.ts
+++ b/cli.ts
@@ -3,10 +3,13 @@
 import { run } from "./index";
 
 const args = require("minimist")(process.argv.slice(2), {
-    alias: {
-      cid: "client_id",
-      tid: "tenant_id"
-    }
-  });
-  
-(async () => await run(args.client_id, args.tenant_id))();
+  alias: {
+    cid: "client_id",
+    tid: "tenant_id",
+    ci: "continuous_integration_variable"
+  }
+});
+
+console.log(args);
+
+(async () => await run(args.client_id, args.tenant_id, args.ci))();

--- a/index.ts
+++ b/index.ts
@@ -11,43 +11,44 @@ const userNpmConfig = new UserNpmConfig();
 const projectNpmConfig = new ProjectNpmConfig();
 
 async function run(clientId = AZDEVOPS_AUTH_CLIENT_ID, tenantId = AZDEVOPS_AUTH_TENANT_ID) {
-  const registry = getRegistry();
-  console.log(chalk.green(`found registry ${registry}`));
+  for(const registry of getRegistries()){
+    console.log(chalk.green(`found registry ${registry}`));
 
-  const issuer = await MsoIssuer.discover(tenantId);
-  const client = new issuer.Client(new MsoDeviceCodeClientMedata(clientId));
+    const issuer = await MsoIssuer.discover(tenantId);
+    const client = new issuer.Client(new MsoDeviceCodeClientMedata(clientId));
 
-  let tokenSet;
-  const refreshToken = userNpmConfig.getRegistryRefreshToken(registry);
-  if (refreshToken) {
-    try {
-      console.log("Trying to use refresh token...");
-      tokenSet = await client.refresh(refreshToken);
-    } catch (exception) {
-      switch (exception.error) {
-        case "invalid_grant":
-          console.log(chalk.yellow("Refresh token is invalid or expired."));
-          tokenSet = await startDeviceCodeFlow(client);
-          break;
-        case "interaction_required":
-          console.log(chalk.yellow("Interaction required."));
-          tokenSet = await startDeviceCodeFlow(client);
-          break;
-        default:
-          throw exception;
+    let tokenSet;
+    const refreshToken = userNpmConfig.getRegistryRefreshToken(registry);
+    if (refreshToken) {
+      try {
+        console.log("Trying to use refresh token...");
+        tokenSet = await client.refresh(refreshToken);
+      } catch (exception) {
+        switch (exception.error) {
+          case "invalid_grant":
+            console.log(chalk.yellow("Refresh token is invalid or expired."));
+            tokenSet = await startDeviceCodeFlow(client);
+            break;
+          case "interaction_required":
+            console.log(chalk.yellow("Interaction required."));
+            tokenSet = await startDeviceCodeFlow(client);
+            break;
+          default:
+            throw exception;
+        }
       }
+    } else {
+      tokenSet = await startDeviceCodeFlow(client);
     }
-  } else {
-    tokenSet = await startDeviceCodeFlow(client);
-  }
 
-  // Update user npm config with tokens
-  userNpmConfig.setRegistryAuthToken(registry, tokenSet.access_token);
-  userNpmConfig.setRegistryRefreshToken(registry, tokenSet.refresh_token);
+    // Update user npm config with tokens
+    userNpmConfig.setRegistryAuthToken(registry, tokenSet.access_token);
+    userNpmConfig.setRegistryRefreshToken(registry, tokenSet.refresh_token);
 
-  console.log(
-    chalk.green(`Done! You can now install packages from ${registry} \n`)
-  );
+    console.log(
+      chalk.green(`Done! You can now install packages from ${registry} \n`)
+    );
+  };
 }
 
 async function startDeviceCodeFlow(client: Client) {
@@ -64,17 +65,21 @@ async function startDeviceCodeFlow(client: Client) {
   return await handle.poll();
 }
 
-function getRegistry() {
-  // Registry should be set on project level but fallback to user defined.`
-  const registry =
-    projectNpmConfig.getRegistry() || userNpmConfig.getRegistry();
-  if (!registry) {
+function getRegistries() {
+  // Registries should be set on project level but fallback to user defined.`
+  const projectRegistries = projectNpmConfig.getRegistries();
+  const userRegistries = userNpmConfig.getRegistries();
+  const registries = (projectRegistries.length !== 0 ? projectRegistries : userRegistries)
+    // return unique list of registries
+    .filter((key, index, keys) => index === keys.indexOf(key));
+
+  if (registries.length === 0) {
     throw new Error(
       "No private registry defined in project .npmrc or user defined .npmrc."
     );
   }
 
-  return registry;
+  return registries;
 };
 
 export { run }

--- a/npm-config/index.ts
+++ b/npm-config/index.ts
@@ -16,9 +16,11 @@ class NpmConfig extends IniConfig {
     super(basePath, createIfNotExists);
   }
 
-  getRegistry() {
-    return this.get("registry");
-  }
+  getRegistries() {
+    return Object.keys(this.config)
+        .filter(key => key.includes("registry"))
+        .map(key => this.get(key))
+  };  
 
   getRegistryRefreshToken(registry: string) {
     const registryUrl = url.parse(registry);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-devops-npm-auth",
-  "version": "0.1.0",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -519,6 +519,12 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
       "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+    },
+    "typescript": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
+      "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==",
+      "dev": true
     },
     "url-parse-lax": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,15 @@
   "name": "azure-devops-npm-auth",
   "version": "1.0.3",
   "description": "Authentication utility for private NPM registries hosted in Azure DevOps.",
-  "keywords": ["azure", "devops", "npm", "authentication", "artifact", "feed", "vsts-npm-auth"],
+  "keywords": [
+    "azure",
+    "devops",
+    "npm",
+    "authentication",
+    "artifact",
+    "feed",
+    "vsts-npm-auth"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
@@ -25,6 +33,7 @@
     "openid-client": "^3.9.1"
   },
   "devDependencies": {
-    "rimraf": "^3.0.0"
+    "rimraf": "^3.0.0",
+    "typescript": "^3.8.2"
   }
 }


### PR DESCRIPTION
This PR fixes #1 

By design when supporting scoped registries, there could be multiple different registries configured. Hence support for handling multiple registries was added to enable scoped repositories.

Note:
The list of repositories is de-duplicated, so even when multiple scopes point to the same registries token for registry is retrieved / refreshed only once per run.

In addition this PR adds a command line parameter `--ci` that allows conditionally skipping authentication when running in CI. This is done by checking if `TF_BUILD` environment variable is set prior to executing auth code.
Its also possible to specify a custom variable name. I have updated the readme accordingly.

