### PR TITLE
Added fallback for user config file

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -40,7 +40,7 @@ async function run(
   const resolvedProjectBasePath = projectBasePath ? resolve(projectBasePath) : process.cwd();
 
   for (const registry of getRegistries(resolvedProjectBasePath)) {
-    console.log(chalk.green(`found registry ${registry}`));
+    console.log(chalk.green(`Found registry ${registry}`));
 
     const issuer = await MsoIssuer.discover(tenantId);
     const client = new issuer.Client(new MsoDeviceCodeClientMedata(clientId));
@@ -87,7 +87,7 @@ async function run(
 }
 
 async function startDeviceCodeFlow(client: Client) {
-  console.log(chalk.green("launching device code authentication..."));
+  console.log(chalk.green("Launching device code authentication..."));
 
   // Make sure to include 'offline_access' scope to receive refresh token.
   const handle = await client.deviceAuthorization({

--- a/npm-config/index.ts
+++ b/npm-config/index.ts
@@ -1,3 +1,4 @@
+import * as os from "os";
 import * as url from "url";
 import * as path from "path";
 import IniConfig from "./ini-config";
@@ -50,9 +51,16 @@ class NpmConfig extends IniConfig {
 
 class UserNpmConfig extends NpmConfig {
   constructor(createIfNotExists = true) {
-    const filePath = execSync("npm config get userconfig")
-      .toString()
-      .trim();
+    let filePath: string;
+    try{
+      filePath = execSync("npm config get userconfig", { stdio: ["pipe", "pipe", "ignore"] })
+        .toString()
+        .trim();
+    }
+    catch {
+      filePath = os.homedir();
+    }
+
     super(filePath, createIfNotExists);
   }
 }


### PR DESCRIPTION
This commit adds a fallback to the user path if the "npm config..." command fails - for example when npm is not installed. Should work with and without npm installed.

Resolves #21 