### PR TITLE
Adding support for Yarn v2+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-devops-npm-auth",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -47,6 +47,12 @@
       "version": "1.3.30",
       "resolved": "https://registry.npmjs.org/@types/ini/-/ini-1.3.30.tgz",
       "integrity": "sha512-2+iF8zPSbpU83UKE+PNd4r/MhwNAdyGpk3H+VMgEH3EhjFZq1kouLgRoZrmIcmoGX97xFvqdS44DkICR5Nz3tQ==",
+      "dev": true
+    },
+    "@types/js-yaml": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+      "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
       "dev": true
     },
     "@types/mocha": {
@@ -120,8 +126,7 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -668,10 +673,9 @@
       }
     },
     "js-yaml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
-      "dev": true,
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -808,6 +812,15 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
           "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
           "dev": true
+        },
+        "js-yaml": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+          "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
         },
         "supports-color": {
           "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -30,11 +30,13 @@
     "chalk": "^3.0.0",
     "ini": "^1.3.8",
     "minimist": "^1.2.5",
-    "openid-client": "^3.15.10"
+    "openid-client": "^3.15.10",
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.15",
     "@types/ini": "^1.3.30",
+    "@types/js-yaml": "^4.0.5",
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.14.31",
     "chai": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-devops-npm-auth",
-  "version": "1.0.13",
+  "version": "1.1.0",
   "description": "Authentication utility for private NPM registries hosted in Azure DevOps.",
   "keywords": [
     "azure",

--- a/tests/yarn-config.test.ts
+++ b/tests/yarn-config.test.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import { YarnConfig, UserYarnConfig, ProjectYarnConfig } from '../yarn-config';
+
+describe('user yarn config', () => {
+    it('user yarn file path not empty', () => {
+        var config = new UserYarnConfig();
+        expect(config.filePath).to.not.be.empty;
+    });
+});
+
+describe('project yarn config', () => {
+    it('project yarn file path not empty', () => {
+        var config = new ProjectYarnConfig(process.cwd());
+        expect(config.filePath).to.not.be.empty;
+    });
+});
+
+describe('yarn config', () => {
+    it('if yarn file doesn\'t exist, get returns undefined.', () => {
+        var config = new YarnConfig("i-dont-exist-path");
+        var value = config.get("something");
+        expect(value).to.be.undefined;
+    });
+    it('if yarn file doesn\'t exist, getRegistries returns empty array.', () => {
+        var config = new YarnConfig("i-dont-exist-path");
+        var value = config.getRegistries();
+        expect(value).to.be.an('array').that.is.empty;
+    });
+});

--- a/yarn-config/index.ts
+++ b/yarn-config/index.ts
@@ -3,8 +3,10 @@ import * as url from "url";
 import * as path from "path";
 import YamlConfig, { YamlSettings } from "./yaml-config";
 import { execSync } from "child_process";
+import { NpmConfig } from "../npm-config";
 
 class YarnConfig extends YamlConfig {
+  private npmConfig: NpmConfig;
   constructor(basePath: string, createIfNotExists = false) {
     if (!basePath) {
       throw new Error("No base path defined for .yarnrc.yml file.");
@@ -15,6 +17,7 @@ class YarnConfig extends YamlConfig {
     }
 
     super(basePath, createIfNotExists);
+    this.npmConfig = new NpmConfig(basePath, createIfNotExists);
   }
 
   getRegistries() {
@@ -39,11 +42,8 @@ class YarnConfig extends YamlConfig {
     return registries;
   }
 
-  getRegistryRefreshToken(_registry: string): string {
-    // Return undefined because the Yarn 2+ Yaml definition doesn't support
-    // a place to store refresh tokens. Maybe there is a way to add this where
-    // Yarn won't complain, but not currently sure how.
-    return undefined;
+  getRegistryRefreshToken(registry: string) {
+    return this.npmConfig.getRegistryRefreshToken(registry);
   }
 
   setRegistryAuthToken(registry: string, token: string) {
@@ -58,11 +58,8 @@ class YarnConfig extends YamlConfig {
     this.save();
   }
 
-  setRegistryRefreshToken(_registry: string, _token: string) {
-    // Return void because the Yarn 2+ Yaml definition doesn't support
-    // a place to store refresh tokens. Maybe there is a way to add this where
-    // Yarn won't complain, but not currently sure how.
-    return;
+  setRegistryRefreshToken(registry: string, token: string) {
+    return this.npmConfig.setRegistryRefreshToken(registry, token);
   }
 }
 

--- a/yarn-config/index.ts
+++ b/yarn-config/index.ts
@@ -1,0 +1,101 @@
+import * as os from "os";
+import * as url from "url";
+import * as path from "path";
+import YamlConfig, { YamlSettings } from "./yaml-config";
+import { execSync } from "child_process";
+
+class YarnConfig extends YamlConfig {
+  constructor(basePath: string, createIfNotExists = false) {
+    if (!basePath) {
+      throw new Error("No base path defined for .yarnrc.yml file.");
+    }
+
+    if (!basePath.endsWith(".yarnrc.yml")) {
+      basePath = path.join(basePath, ".yarnrc.yml");
+    }
+
+    super(basePath, createIfNotExists);
+  }
+
+  getRegistries() {
+    return this.getRegistriesHelper(this.config);
+  };
+
+  private getRegistriesHelper(config: YamlSettings) {
+    const configKeys = Object.keys(config);
+    let registries: string[] = [];
+
+    configKeys.forEach(key => {
+      const settingValue = config[key];
+      if (typeof settingValue === "object") {
+        registries.push(...this.getRegistriesHelper(settingValue))
+      } else {
+        if (key.indexOf("npmRegistryServer") > -1) {
+          registries.push(settingValue);
+        }
+      }
+    });
+
+    return registries;
+  }
+
+  getRegistryRefreshToken(_registry: string): string {
+    // Return undefined because the Yarn 2+ Yaml definition doesn't support
+    // a place to store refresh tokens. Maybe there is a way to add this where
+    // Yarn won't complain, but not currently sure how.
+    return undefined;
+  }
+
+  setRegistryAuthToken(registry: string, token: string) {
+    const registryUrl = url.parse(registry);
+    const registryKey: string = `${registryUrl.hostname}${registryUrl.pathname}`;
+    this.set('npmRegistries', {
+      ...(typeof this.get('npmRegistries') === 'object' ? this.get('npmRegistries') as YamlSettings : {}),
+      [registryKey]: {
+        'npmAuthToken': token
+      }
+    });
+    this.save();
+  }
+
+  setRegistryRefreshToken(_registry: string, _token: string) {
+    // Return void because the Yarn 2+ Yaml definition doesn't support
+    // a place to store refresh tokens. Maybe there is a way to add this where
+    // Yarn won't complain, but not currently sure how.
+    return;
+  }
+}
+
+class UserYarnConfig extends YarnConfig {
+  constructor(createIfNotExists = true) {
+    let filePath: string;
+    try{
+      filePath = execSync("npm config get userconfig", { stdio: ["pipe", "pipe", "ignore"] })
+        .toString()
+        .trim();
+    }
+    catch {
+      filePath = os.homedir();
+    }
+    if (filePath.endsWith(".npmrc")) {
+      filePath = path.join(filePath.substring(0, filePath.length - ".npmrc".length), ".yarnrc.yml");
+    } else {
+      filePath = path.join(filePath, ".yarnrc.yml");
+    }
+
+    super(filePath, createIfNotExists);
+  }
+}
+
+class ProjectYarnConfig extends YarnConfig {
+  constructor(basePath: string) {
+    const filePath = path.join(basePath, ".yarnrc.yml");
+    super(filePath);
+  }
+}
+
+export {
+  YarnConfig,
+  UserYarnConfig,
+  ProjectYarnConfig
+};

--- a/yarn-config/index.ts
+++ b/yarn-config/index.ts
@@ -12,12 +12,18 @@ class YarnConfig extends YamlConfig {
       throw new Error("No base path defined for .yarnrc.yml file.");
     }
 
-    if (!basePath.endsWith(".yarnrc.yml")) {
-      basePath = path.join(basePath, ".yarnrc.yml");
+    let yarnBasePath = basePath;
+    if (!yarnBasePath.endsWith(".yarnrc.yml")) {
+      yarnBasePath = path.join(yarnBasePath, ".yarnrc.yml");
     }
 
-    super(basePath, createIfNotExists);
-    this.npmConfig = new NpmConfig(basePath, createIfNotExists);
+    super(yarnBasePath, createIfNotExists);
+
+    let npmBasePath = basePath;
+    if (npmBasePath.endsWith('.yarnrc.yml')) {
+      npmBasePath = path.join(npmBasePath.substring(0, npmBasePath.length - ".yarnrc.yml".length), ".npmrc");
+    }
+    this.npmConfig = new NpmConfig(npmBasePath, createIfNotExists);
   }
 
   getRegistries() {

--- a/yarn-config/yaml-config.ts
+++ b/yarn-config/yaml-config.ts
@@ -30,7 +30,6 @@ class YamlConfig {
 
     save = () => fs.writeFileSync(this.filePath, yaml.dump(this.config));
 
-    // load = () => this.config = ini.parse(fs.readFileSync(this.filePath, "utf8"));
     load = () => this.config = yaml.load(fs.readFileSync(this.filePath, "utf8")) as YamlSettings;
 }
 

--- a/yarn-config/yaml-config.ts
+++ b/yarn-config/yaml-config.ts
@@ -1,0 +1,37 @@
+import * as fs from "fs";
+import * as yaml from 'js-yaml';
+
+export type YamlSettings = {
+    [key: string]: YamlSettings | string;
+}
+
+class YamlConfig {
+
+    filePath: string;
+
+    config: YamlSettings;
+
+    constructor(filePath: string, createIfNotExists = false) {
+        this.filePath = filePath;
+        this.config = {};
+
+        if (!fs.existsSync(filePath) && createIfNotExists) {
+            fs.writeFileSync(filePath, yaml.dump({}));
+        }
+
+        if (fs.existsSync(filePath)) {
+            this.load();
+        }
+    }
+
+    get = (key: string) => this.config[key];
+
+    set = (key: string, value: string | YamlSettings) => this.config[key] = value;
+
+    save = () => fs.writeFileSync(this.filePath, yaml.dump(this.config));
+
+    // load = () => this.config = ini.parse(fs.readFileSync(this.filePath, "utf8"));
+    load = () => this.config = yaml.load(fs.readFileSync(this.filePath, "utf8")) as YamlSettings;
+}
+
+export default YamlConfig;


### PR DESCRIPTION
Adds support for Yarn v2+

- Adds an additional `yarn-config` directory which contains the logic for interacting with the `.yarnrc.yml` file
- Adds condition logic into the cli which checks to see the project is using Yarn v2+ and then uses the appropriate Yarn config class.