### PR TITLE
chore: ensure advanced use steps works on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you want to use your own Azure Active Directory application, it's possible to
 
 ```javascript
   "scripts": {
-    "preinstall": "azure-devops-npm-auth --client_id='xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' --tenant_id='xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'"
+    "preinstall": "azure-devops-npm-auth --client_id=xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --tenant_id=xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
     ...
   },
 ```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you want to use your own Azure Active Directory application, it's possible to
 
 ```javascript
   "scripts": {
-    "preinstall": "azure-devops-npm-auth --client_id=xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --tenant_id=xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    "preinstall": "npx azure-devops-npm-auth --client_id=xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --tenant_id=xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
     ...
   },
 ```
@@ -72,14 +72,14 @@ This will open your default browser where you will need to login to Azure with c
 To disable authentication within CI environments add the `--ci` flag which skips authentication when the `TF_BUILD` environment variable is set (which is automatically set in Azure DevOps build pipelines):
 ```javascript
   "scripts": {
-    "preinstall": "azure-devops-npm-auth --ci"
+    "preinstall": "npx azure-devops-npm-auth --ci"
     ...
   },
 ```
 It's also possible to specify a custom environment variable:
 ```javascript
   "scripts": {
-    "preinstall": "azure-devops-npm-auth --ci=MY_CUSTOM_VARIABLE"
+    "preinstall": "npx azure-devops-npm-auth --ci=MY_CUSTOM_VARIABLE"
     ...
   },
 ```
@@ -90,7 +90,7 @@ You can pass in a path to customize the directory to look in for the project's .
 
 ```javascript
   "scripts": {
-    "preinstall": "azure-devops-npm-auth --project_base_path=./configs"
+    "preinstall": "npx azure-devops-npm-auth --project_base_path=./configs"
     ...
   },
 ```

--- a/register-azure-devops-npm-auth.ps1
+++ b/register-azure-devops-npm-auth.ps1
@@ -128,7 +128,7 @@ process {
         Write-Host '******************* Summary: start ******************************'
         Write-Host "App/Client ID: $($app.appId)"
         Write-Host "AD Tenant ID: $tenantId"
-        Write-Host ("To authenticate to Azure npm feed: azure-devops-npm-auth --client_id='{0}' --tenant_id='{1}'" -f $app.appId, $tenantId) -ForegroundColor Yellow
+        Write-Host ("To authenticate to Azure npm feed: azure-devops-npm-auth --client_id={0} --tenant_id={1}" -f $app.appId, $tenantId) -ForegroundColor Yellow
         Write-Host '******************* Summary: end ********************************'
 
     }


### PR DESCRIPTION
on windows using the preinstall script with single quotes fails

Example:

```json
{
  "preinstall": "npx azure-devops-npm-auth@1.0.13 --client_id='redacted-client-id' --tenant_id='redacted-tenant-id' --ci=CI_BUILD"
}
```

produces the following error:

```cmd
OPError: invalid_tenant (AADSTS90002: Tenant ''redacted-tenant-id'' not found. Check to make sure you have the correct tenant ID and are signing into the correct cloud. Check with your subscription administrator, this may happen if there are no active subscriptions for the tenant.
Trace ID: 7fa28a92-68d2-4a61-a4f7-683cf7856a00
Correlation ID: 0bca9cba-584e-4f49-b795-1a30a123dd26
Timestamp: 2022-04-07 15:30:34Z)
    at processResponse (C:\PD\tools\node_cache\_npx\7fde29e10f8043c0\node_modules\openid-client\lib\helpers\process_response.js:45:13)
    at Function.discover (C:\PD\tools\node_cache\_npx\7fde29e10f8043c0\node_modules\openid-client\lib\issuer.js:220:20)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  error: 'invalid_tenant',
  error_description: "AADSTS90002: Tenant ''redacted-tenant-id'' not found. Check to make sure you have the correct tenant ID and are signing into the correct cloud. Check with your subscription administrator, this may happen if there are no active subscriptions for the tenant.\r\n" +
    'Trace ID: 7fa28a92-68d2-4a61-a4f7-683cf7856a00\r\n' +
    'Correlation ID: 0bca9cba-584e-4f49-b795-1a30a123dd26\r\n' +
    'Timestamp: 2022-04-07 15:30:34Z',
  error_uri: 'https://login.microsoftonline.com/error?code=90002'
```