### PR TITLE
Fix error using refresh token

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -11,4 +11,4 @@ const args = require("minimist")(process.argv.slice(2), {
   }
 });
 
-(async () => await run(args.client_id, args.tenant_id, args.ci, args.pbp))();
+(async () => await run(args.client_id, args.ci, args.tenant_id, args.pbp))();

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,7 @@ import * as path from 'path';
 const AZDEVOPS_AUTH_TENANT_HEADER = "x-vss-resourcetenant";
 
 const AZDEVOPS_RESOURCE_ID = "499b84ac-1321-427f-aa17-267ca6975798";
-const AZDEVOPS_AUTH_CLIENT_ID = "f9d5fef7-a410-4582-bb27-68a319b1e5a1";
+const AZDEVOPS_AUTH_CLIENT_ID = "872cd9fa-d31f-45e0-9eab-6e460a02d1f1";
 const AZDEVOPS_AUTH_TENANT_ID = "common";
 
 const CI_DEFAULT_ENV_VARIABLE_NAME = "TF_BUILD";


### PR DESCRIPTION
Fix #27.

Azure Artifacts feed response has `"x-vss-resourcetenant"` header, which we can read the `tenantId` from if it's not set in CLI arguments.

Set default `clientId` to the one from [microsoft/artifacts-credprovider](https://github.com/microsoft/artifacts-credprovider/blob/2286b12bf6e106386c7c530bf0a7220306cbf57c/CredentialProvider.Microsoft/CredentialProviders/Vsts/MSAL/MsalTokenProviderFactory.cs#L12). This should work with all feeds.